### PR TITLE
#8 - Fix autocomplete component by adding a missing super.renderHead call

### DIFF
--- a/wiquery-jquery-ui/src/main/java/org/odlabs/wiquery/ui/autocomplete/AbstractAutocompleteComponent.java
+++ b/wiquery-jquery-ui/src/main/java/org/odlabs/wiquery/ui/autocomplete/AbstractAutocompleteComponent.java
@@ -86,6 +86,7 @@ public abstract class AbstractAutocompleteComponent<T> extends FormComponentPane
 		@Override
 		public void renderHead(IHeaderResponse response)
 		{
+			super.renderHead(response);
 			response.render(JavaScriptHeaderItem
 				.forReference(WiQueryAutocompleteJavaScriptResourceReference.get()));
 		}


### PR DESCRIPTION
As the super.renderHead call is missing, the code needed to make the autocomplete work isn't contributed at all.
