### PR TITLE
Fixed NPE using Tabs component with no ajax events configured

### DIFF
--- a/wiquery-jquery-ui/src/main/java/org/odlabs/wiquery/ui/tabs/Tabs.java
+++ b/wiquery-jquery-ui/src/main/java/org/odlabs/wiquery/ui/tabs/Tabs.java
@@ -123,7 +123,10 @@ public class Tabs extends WebMarkupContainer
 		@Override
 		protected void updateAjaxAttributes(AjaxRequestAttributes attributes)
 		{
-			attributes.getDynamicExtraParameters().addAll(extraDynParams);
+			if (extraDynParams != null)
+			{
+				attributes.getDynamicExtraParameters().addAll(extraDynParams);
+			}
 		}
 		
 		protected void setDynParams(List<String> list)


### PR DESCRIPTION
The Tabs component will give a NPE when the user has not configured any of the (new) ajax events for the component. The ajax based events are new, when upgrading from an older WiQuery all existing Tab components will get the NPE.

Added a simple null check around the extraDynParams field before trying to add them in de updateAjaxAttributes method.
