### PR TITLE
Update to latest 7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -394,7 +394,7 @@
 							!org.odlabs.wiquery*,
 							!com.yahoo.platform.yui.compressor*,
 							!org.mozilla.javascript*,
-							org.codehaus.jackson*;version="${jackson.version}",
+							com.fasterxml.jackson*;version="${jackson.version}",
 							org.apache.wicket*;version="${wicket.version}",
 							org.slf4j*;version="${slf4j.version}",
 							*
@@ -408,4 +408,18 @@
 			</plugin>
 		</plugins>
 	</build>
+	
+	<distributionManagement>
+		<repository>
+			<id>nexus-owsi-core</id>
+			<name>Nexus OWSI Core</name>
+			<url>https://projects.openwide.fr/services/nexus/content/repositories/owsi-core</url>
+		</repository>
+		<snapshotRepository>
+			<id>nexus-owsi-core-snapshots</id>
+			<name>Nexus OWSI Core Snapshots</name>
+			<url>https://projects.openwide.fr/services/nexus/content/repositories/owsi-core-snapshots</url>
+		</snapshotRepository>
+	</distributionManagement>
+	
 </project>

--- a/wiquery-jquery-ui/src/main/java/org/odlabs/wiquery/ui/autocomplete/AbstractAutocompleteComponent.java
+++ b/wiquery-jquery-ui/src/main/java/org/odlabs/wiquery/ui/autocomplete/AbstractAutocompleteComponent.java
@@ -283,7 +283,7 @@ public abstract class AbstractAutocompleteComponent<T> extends FormComponentPane
 	}
 
 	@Override
-	protected final void convertInput()
+	public final void convertInput()
 	{
 		String valueId = autocompleteHidden.getConvertedInput();
 		String input = autocompleteField.getConvertedInput();

--- a/wiquery-jquery-ui/src/main/java/org/odlabs/wiquery/ui/button/ButtonCheckSet.java
+++ b/wiquery-jquery-ui/src/main/java/org/odlabs/wiquery/ui/button/ButtonCheckSet.java
@@ -96,7 +96,7 @@ public class ButtonCheckSet<T extends Serializable> extends Panel
 			private static final long serialVersionUID = 8265281439115476364L;
 
 			@Override
-			protected void onSelectionChanged(final Collection< ? extends T> newSelection)
+			protected void onSelectionChanged(final Collection<T> newSelection)
 			{
 				ButtonCheckSet.this.onSelectionChanged(newSelection);
 			}

--- a/wiquery-jquery-ui/src/main/java/org/odlabs/wiquery/ui/button/ButtonRadioSet.java
+++ b/wiquery-jquery-ui/src/main/java/org/odlabs/wiquery/ui/button/ButtonRadioSet.java
@@ -91,7 +91,7 @@ public class ButtonRadioSet<T extends Serializable> extends Panel
 			private static final long serialVersionUID = 8265281439115476364L;
 
 			@Override
-			protected void onSelectionChanged(Object newSelection)
+			protected void onSelectionChanged(T newSelection)
 			{
 				ButtonRadioSet.this.onSelectionChanged(newSelection);
 			}

--- a/wiquery-jquery-ui/src/main/java/org/odlabs/wiquery/ui/button/ButtonRadioSet.java
+++ b/wiquery-jquery-ui/src/main/java/org/odlabs/wiquery/ui/button/ButtonRadioSet.java
@@ -68,7 +68,7 @@ public class ButtonRadioSet<T extends Serializable> extends Panel
 	 * @param radios
 	 *            List of radios
 	 */
-	public ButtonRadioSet(String id, IModel<List< ? extends ButtonElement<T>>> radios)
+	public ButtonRadioSet(String id, IModel<? extends List< ? extends ButtonElement<T>>> radios)
 	{
 		this(id, radios, new Model<T>());
 	}
@@ -81,7 +81,7 @@ public class ButtonRadioSet<T extends Serializable> extends Panel
 	 * @param radios
 	 *            List of radios
 	 */
-	public ButtonRadioSet(String id, IModel<List< ? extends ButtonElement<T>>> radios,
+	public ButtonRadioSet(String id, IModel<? extends List< ? extends ButtonElement<T>>> radios,
 			IModel<T> model)
 	{
 		super(id);


### PR DESCRIPTION
Hi Hielke!

Here are a couple of fixes to compilation issues with the latest Wicket 7.

There are still 2 compilation issues with generics in ButtonRadioSet list constructors but I haven't found a way to fix them.

Would you mind taking a look?

Maybe we could then release a first M1 of wiQuery 7 so that people can begin to test it with Wicket 7.

Thanks!

-- 
Guillaume